### PR TITLE
Dynamic databases and store schema

### DIFF
--- a/example/BlazorDB.Example/Pages/Index.razor
+++ b/example/BlazorDB.Example/Pages/Index.razor
@@ -47,6 +47,28 @@
 <button @onclick="WhereNameAndId">Where Id and Name</button>
 <button @onclick="ViolateUniqueness">Violate index uniqueness</button>
 
+<h1>Employee (Dynamic)</h1>
+<button @onclick="SwitchToEmployee">Switch</button>
+<button @onclick="AddSchema">Add Schema</button>
+<button @onclick="Add">Add</button>
+<button @onclick="Put">Put</button>
+<button @onclick="Add100">Add 100</button>
+<button @onclick="Add100Async">Add 100 (Async)</button>
+<button @onclick="BulkAdd">BulkAdd 10,000</button>
+<button @onclick="BulkAddAsync">BulkAdd 10,000 (Async)</button>
+<button @onclick="Update">Update</button>
+<button @onclick="UpdateAsync">Update (Async)</button>
+<button @onclick="Delete">Delete</button>
+<button @onclick="DeleteAsync">Delete (Async)</button>
+<button @onclick="GetItem">Get Item</button>
+<button @onclick="ToArray">ToArray</button>
+<button @onclick="AddWithCallback">Add With Callback</button>
+<button @onclick="DeleteDb">Delete DB</button>
+<button @onclick="WhereId">Where Id</button>
+<button @onclick="WhereNameAndId">Where Id and Name</button>
+<button @onclick="ViolateUniqueness">Violate index uniqueness</button>
+
+
 @code {
     IndexedDbManager manager;
 
@@ -74,6 +96,23 @@
         dbName = "Test";
         storeName = "Person";
         manager = await _dbFactory.GetDbManager(dbName);
+    }
+
+    protected async void SwitchToEmployee()
+    {
+        dbName = "Test3";
+        storeName = "Employee";
+        manager = await _dbFactory.GetDbManager(dbName);
+        manager.ActionCompleted += (_, __) =>
+        {
+            Console.WriteLine(__.Message);
+        };
+    }
+
+    protected async void AddSchema()
+    {
+        var schema = new StoreSchema() { Name = storeName, PrimaryKey = "id", PrimaryKeyAuto = true, Indexes = { "name"}, UniqueIndexes = { "guid" } };
+        await manager.AddSchema(schema);
     }
 
     protected async Task Create()

--- a/src/BlazorDB/BlazorDbFactory.cs
+++ b/src/BlazorDB/BlazorDbFactory.cs
@@ -12,6 +12,7 @@ namespace BlazorDB
         readonly IJSRuntime _jsRuntime;
         readonly IServiceProvider _serviceProvider;
         readonly IDictionary<string, IndexedDbManager> _dbs = new Dictionary<string, IndexedDbManager>();
+        const string InteropPrefix = "window.blazorDB";
 
         public BlazorDbFactory(IServiceProvider serviceProvider, IJSRuntime jSRuntime)
         {
@@ -25,8 +26,12 @@ namespace BlazorDB
                 await BuildFromServices();
             if(_dbs.ContainsKey(dbName))
                 return _dbs[dbName];
-            
-            return null;
+            if ((await GetDbNames()).Contains(dbName))
+                await BuildExistingDynamic(dbName);
+            else
+                await BuildNewDynamic(dbName);
+
+            return _dbs[dbName];
         }
 
         public Task<IndexedDbManager> GetDbManager(DbStore dbStore)
@@ -40,10 +45,50 @@ namespace BlazorDB
                 foreach(var dbStore in dbStores)
                 {
                     Console.WriteLine($"{dbStore.Name}{dbStore.Version}{dbStore.StoreSchemas.Count}");
-                    var db = new IndexedDbManager(dbStore, _jsRuntime);
+                    var db = new IndexedDbManager(dbStore, _jsRuntime, _dbs);
                     await db.OpenDb();
                     _dbs.Add(dbStore.Name, db);
                 }
+            }
+        }
+
+        async Task BuildExistingDynamic(string dbName)
+        {
+            var dbStore = await GetDbStoreDynamic(dbName);
+            var db = new IndexedDbManager(dbStore, _jsRuntime, _dbs);
+            _dbs.Add(dbStore.Name, db);
+        }
+
+        async Task BuildNewDynamic(string dbName)
+        {
+            var newDbStore = new DbStore() { Name = dbName, StoreSchemas = new(), Version = 0, Dynamic = true };
+            var newDb = new IndexedDbManager(newDbStore, _jsRuntime, _dbs);
+            await newDb.OpenDb();
+            newDbStore.Version = 1;
+            _dbs.Add(newDbStore.Name, newDb);
+        }
+
+        public async Task<string[]> GetDbNames()
+        {
+            try
+            {
+                return await _jsRuntime.InvokeAsync<string[]>($"{InteropPrefix}.{IndexedDbFunctions.GET_DB_NAMES}");
+            }
+            catch (JSException jse)
+            {
+                throw new Exception($"Could not get database names. JavaScript exception: {jse.Message}");
+            }
+        }
+
+        async Task<DbStore> GetDbStoreDynamic(string dbName)
+        {
+            try
+            {
+                return await _jsRuntime.InvokeAsync<DbStore>($"{InteropPrefix}.{IndexedDbFunctions.GET_DB_STORE_DYNAMIC}", new object[] { dbName });
+            }
+            catch (JSException jse)
+            {
+                throw new Exception($"Could not get dynamic database store configuration. JavaScript exception: {jse.Message}");
             }
         }
     }

--- a/src/BlazorDB/DbStore.cs
+++ b/src/BlazorDB/DbStore.cs
@@ -7,5 +7,6 @@ namespace BlazorDB
         public string Name { get; set; }
         public int Version { get; set; }
         public List<StoreSchema> StoreSchemas { get; set; }
+        public bool Dynamic { get; set; } = false;
     }
 }

--- a/src/BlazorDB/IndexedDbFunctions.cs
+++ b/src/BlazorDB/IndexedDbFunctions.cs
@@ -4,6 +4,9 @@ namespace BlazorDB
     {
         public const string CREATE_DB = "createDb";
         public const string DELETE_DB = "deleteDb";
+        public const string GET_DB_NAMES = "getDbNames";
+        public const string GET_DB_STORE_DYNAMIC = "getDbStoreDynamic";
+        public const string ADD_SCHEMA = "addSchema";
         public const string ADD_ITEM = "addItem";
         public const string BULKADD_ITEM = "bulkAddItem";
         public const string PUT_ITEM = "putItem";


### PR DESCRIPTION
This starts to address #9. If a manager is requested, but the database name does not exist, it will create a new dynamic database; then, store schema must be defined for it before database can receive data. `DbStore` class now has a property to distinguish dynamic versus static databases. Behavior of static databases and methods for operating on them should not be affected by this PR.