### PR TITLE
feat: support returning DbResult as a JsonDocument for `addItem` and …

### DIFF
--- a/src/BlazorDB/BlazorDbEvent.cs
+++ b/src/BlazorDB/BlazorDbEvent.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.Json;
 
 namespace BlazorDB
 {
@@ -7,5 +8,6 @@ namespace BlazorDB
         public Guid Transaction { get; set; }
         public bool Failed { get; set; }
         public string Message { get; set; }
+        public JsonDocument DbResult { get; set; }
     }
 }

--- a/src/BlazorDB/IndexDbManager.cs
+++ b/src/BlazorDB/IndexDbManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.JSInterop;
 
@@ -422,7 +423,7 @@ namespace BlazorDB
         }
 
         [JSInvokable("BlazorDBCallback")]
-        public void CalledFromJS(Guid transaction, bool failed, string message)
+        public void CalledFromJS(Guid transaction, bool failed, string message, JsonDocument dbResult)
         {
             if(transaction != Guid.Empty)
             {
@@ -436,7 +437,8 @@ namespace BlazorDB
                     {
                         Transaction = transaction,
                         Message = message,
-                        Failed = failed
+                        Failed = failed,
+                        DbResult = dbResult,
                     });
                     _transactions.Remove(transaction);
                 }
@@ -446,7 +448,8 @@ namespace BlazorDB
                     {
                         Transaction = transaction,
                         Message = message,
-                        Failed = failed
+                        Failed = failed,
+                        DbResult = dbResult,
                     });
                     _taskTransactions.Remove(transaction);
                 }
@@ -509,7 +512,7 @@ namespace BlazorDB
             return transaction;
         }
 
-        void RaiseEvent(Guid transaction, bool failed, string message)
-            => ActionCompleted?.Invoke(this, new BlazorDbEvent { Transaction = transaction, Failed = failed, Message = message });
+        void RaiseEvent(Guid transaction, bool failed, string message, JsonDocument recordId = null)
+            => ActionCompleted?.Invoke(this, new BlazorDbEvent { Transaction = transaction, Failed = failed, Message = message, DbResult = recordId });
     }
 }

--- a/src/BlazorDB/wwwroot/blazorDB.js
+++ b/src/BlazorDB/wwwroot/blazorDB.js
@@ -42,10 +42,10 @@ window.blazorDB = {
             });
         }
         db.open().then(_ => {
-            dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, false, 'Database opened');
+            dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, false, 'Database opened', null);
         }).catch(e => {
             console.error(e);
-            dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, true, 'Database could not be opened');
+            dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, true, 'Database could not be opened', null);
         });
     },
     deleteDb: function(dotnetReference, transaction, dbName) {
@@ -53,70 +53,70 @@ window.blazorDB = {
             var index = window.blazorDB.databases.findIndex(d => d.name == dbName);
             window.blazorDB.databases.splice(index, 1);
             db.delete().then(_ => {
-                dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, false, 'Database deleted');
+                dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, false, 'Database deleted', null);
             }).catch(e => {
                 console.error(e);
-                dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, true, 'Database could not be deleted');
+                dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, true, 'Database could not be deleted', null);
             });
         });
     },
     addItem: function(dotnetReference, transaction, item) {
         window.blazorDB.getTable(item.dbName, item.storeName).then(table => {
-            table.add(item.record).then(_ => {
-                dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, false, 'Item added');
+            table.add(item.record).then(result => {
+                dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, false, 'Item added', result);
             }).catch(e => {
                 console.error(e);
-                dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, true, 'Item could not be added');
+                dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, true, 'Item could not be added', null);
             });
         });
     },
     bulkAddItem: function(dotnetReference, transaction, dbName, storeName, items) {
         window.blazorDB.getTable(dbName, storeName).then(table => {
-            table.bulkAdd(items).then(_ => {
-                dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, false, 'Item(s) bulk added');
+            table.bulkAdd(items).then(result => {
+                dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, false, 'Item(s) bulk added', result);
             }).catch(e => {
                 console.error(e);
-                dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, true, 'Item(s) could not be bulk added');
+                dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, true, 'Item(s) could not be bulk added', null);
             });
         });
     },
     putItem: function(dotnetReference, transaction, item) {
         window.blazorDB.getTable(item.dbName, item.storeName).then(table => {
             table.put(item.record).then(_ => {
-                dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, false, 'Item put successful');
+                dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, false, 'Item put successful', null);
             }).catch(e => {
                 console.error(e);
-                dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, true, 'Item put failed');
+                dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, true, 'Item put failed', null);
             });
         });
     },
     updateItem: function(dotnetReference, transaction, item) {
         window.blazorDB.getTable(item.dbName, item.storeName).then(table => {
             table.update(item.key, item.record).then(_ => {
-                dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, false, 'Item updated');
+                dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, false, 'Item updated', null);
             }).catch(e => {
                 console.error(e);
-                dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, true, 'Item could not be updated');
+                dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, true, 'Item could not be updated', null);
             });
         });
     },
     deleteItem: function(dotnetReference, transaction, item) {
         window.blazorDB.getTable(item.dbName, item.storeName).then(table => {
             table.delete(item.key).then(_ => {
-                dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, false, 'Item deleted');
+                dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, false, 'Item deleted', null);
             }).catch(e => {
                 console.error(e);
-                dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, true, 'Item could not be deleted');
+                dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, true, 'Item could not be deleted', null);
             });
         });
     },
     clear: function(dotnetReference, transaction, dbName, storeName) {
         window.blazorDB.getTable(dbName, storeName).then(table => {
             table.clear().then(_ => {
-                dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, false, 'Table cleared');
+                dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, false, 'Table cleared', null);
             }).catch(e => {
                 console.error(e);
-                dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, true, 'Table could not be cleared');
+                dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, true, 'Table could not be cleared', null);
             });
         });
     },
@@ -124,11 +124,11 @@ window.blazorDB = {
         var promise = new Promise((resolve, reject) => {
             window.blazorDB.getTable(item.dbName, item.storeName).then(table => {
                 table.get(item.key).then(i => {
-                    dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, false, 'Found item');
+                    dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, false, 'Found item', null);
                     resolve(i);
                 }).catch(e => {
                     console.error(e);
-                    dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, true, 'Could not find item');
+                    dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, true, 'Could not find item', null);
                     reject(e);
                 });
             });
@@ -139,11 +139,11 @@ window.blazorDB = {
         return new Promise((resolve, reject) => {
             window.blazorDB.getTable(dbName, storeName).then(table => {
                 table.toArray(items => {
-                    dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, false, 'toArray succeeded');
+                    dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, false, 'toArray succeeded', null);
                     resolve(items);
                 }).catch(e => {
                     console.error(e);
-                    dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, true, 'toArray failed');
+                    dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, true, 'toArray failed', null);
                     reject(e);
                 });
             });
@@ -196,12 +196,12 @@ window.blazorDB = {
         return new Promise((resolve, reject) => {
             window.blazorDB.getTable(dbName, storeName).then(table => {
                 table.where(filterObject).toArray(items => {
-                    dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, false, 'where succeeded');
+                    dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, false, 'where succeeded', null);
                     resolve(items);
                 })
             }).catch(e => {
                 console.error(e);
-                dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, true, 'where failed');
+                dotnetReference.invokeMethodAsync('BlazorDBCallback', transaction, true, 'where failed', null);
                 reject(e);
             });
         });


### PR DESCRIPTION
### feat: support returning DbResult as a JsonDocument for `addItem` and `bulkAddItem` methods.

Currently it's not possible to read the ID of objects inserted in stores via `AddRecordAsync` and friends, which makes retrieval of the new object ID tedious when the store has been set up to use auto incrementing primary keys.

This patch introduces support for encapsulating the Dexie result on add and bulkAdd on the JS side encoded as a JsonDocument, that way we can introspect the returned document and retireve ID tokens if needed.

I intentionally opted for JsonDocument given that `BlazorDbEvent` class is not generic and it's too difficult to add cases for all the serialization rules.

According to https://developer.mozilla.org/en-US/docs/Web/API/IDBCursor/primaryKey the spec says primary key fields can be of any type.